### PR TITLE
Miss Marking Improvements

### DIFF
--- a/flare-fastutil/src/main/template/primitive/space/vectrix/flare/fastutil/{{K}}2ObjectSyncMapImpl.java.peb
+++ b/flare-fastutil/src/main/template/primitive/space/vectrix/flare/fastutil/{{K}}2ObjectSyncMapImpl.java.peb
@@ -55,7 +55,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           entry = this.dirty.get(key);
           // The slow path should be avoided, even if the value does
           // not match or is present. So we mark a miss, to eventually
@@ -128,7 +128,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           entry = this.dirty.remove(key);
           // The slow path should be avoided, even if the value does
           // not match or is present. So we mark a miss, to eventually
@@ -147,7 +147,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           if((entry = this.dirty.get(key)) != null && entry.replace(value, null)) {
             entry = this.dirty.remove(key);
           } else {
@@ -215,7 +215,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           if((entry = this.dirty.get(key)) != null && !entry.replace(oldValue, newValue)) {
             entry = null;
           }

--- a/flare-fastutil/src/main/template/primitive/space/vectrix/flare/fastutil/{{K}}2ObjectSyncMapImpl.java.peb
+++ b/flare-fastutil/src/main/template/primitive/space/vectrix/flare/fastutil/{{K}}2ObjectSyncMapImpl.java.peb
@@ -57,6 +57,9 @@ import java.util.function.IntFunction;
       synchronized(this.lock) {
         if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
           entry = this.dirty.get(key);
+          // The slow path should be avoided, even if the value does
+          // not match or is present. So we mark a miss, to eventually
+          // promote and take a faster path.
           this.missLocked();
         }
       }
@@ -101,6 +104,7 @@ import java.util.function.IntFunction;
         if(entry != null) {
           previous = entry.get();
           entry.set(value);
+          this.missLocked();
         } else if(!present) {
           if(!this.readAmended) {
             this.dirtyLocked();
@@ -126,6 +130,10 @@ import java.util.function.IntFunction;
       synchronized(this.lock) {
         if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
           entry = this.dirty.remove(key);
+          // The slow path should be avoided, even if the value does
+          // not match or is present. So we mark a miss, to eventually
+          // promote and take a faster path.
+          this.missLocked();
         }
       }
     }
@@ -137,19 +145,23 @@ import java.util.function.IntFunction;
   public boolean remove(final {{ k }} key, final @NonNull Object value) {
     requireNonNull(value, "value");
     ExpungingValue<V> entry = this.read.get(key);
-    boolean absent = entry == null;
-    if(absent && this.readAmended) {
+    if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (absent = (entry = this.read.get(key)) == null) && this.dirty != null) {
-          absent = (entry = this.dirty.get(key)) == null;
-          if(!absent && entry.replace(value, null)) {
-            this.dirty.remove(key);
-            return true;
+        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+          if((entry = this.dirty.get(key)) != null && entry.replace(value, null)) {
+            entry = this.dirty.remove(key);
+          } else {
+            entry = null;
           }
+          // The slow path should be avoided, even if the value does
+          // not match or is present. So we mark a miss, to eventually
+          // promote and take a faster path.
+          this.missLocked();
+          return entry != null;
         }
       }
     }
-    return !absent && entry.replace(value, null);
+    return entry != null && entry.replace(value, null);
   }
 
   @Override
@@ -172,6 +184,7 @@ import java.util.function.IntFunction;
         entry = this.dirty != null ? this.dirty.get(key) : null;
         if(entry != null) {
           result = entry.putIfAbsent(value);
+          this.missLocked();
         } else {
           if(!this.readAmended) {
             this.dirtyLocked();
@@ -200,16 +213,21 @@ import java.util.function.IntFunction;
     requireNonNull(oldValue, "oldValue");
     requireNonNull(newValue, "newValue");
     ExpungingValue<V> entry = this.read.get(key);
-    if(entry != null && entry.replace(oldValue, newValue)) return true;
-    if(this.readAmended) {
+    if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && this.dirty != null) {
-          entry = this.dirty.get(key);
-          if(entry.replace(oldValue, newValue)) return true;
+        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+          if((entry = this.dirty.get(key)) != null && !entry.replace(oldValue, newValue)) {
+            entry = null;
+          }
+          // The slow path should be avoided, even if the value does
+          // not match or is present. So we mark a miss, to eventually
+          // promote and take a faster path.
+          this.missLocked();
+          return entry != null;
         }
       }
     }
-    return false;
+    return entry != null && entry.replace(oldValue, newValue);
   }
 
   @Override

--- a/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
+++ b/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
@@ -75,7 +75,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           entry = this.dirty.get(key);
           // The slow path should be avoided, even if the value does
           // not match or is present. So we mark a miss, to eventually
@@ -148,7 +148,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           entry = this.dirty.remove(key);
           // The slow path should be avoided, even if the value does
           // not match or is present. So we mark a miss, to eventually
@@ -167,7 +167,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           if((entry = this.dirty.get(key)) != null && entry.replace(value, null)) {
             entry = this.dirty.remove(key);
           } else {
@@ -235,7 +235,7 @@ import java.util.function.IntFunction;
     ExpungingValue<V> entry = this.read.get(key);
     if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
+        if((entry = this.read.get(key)) == null && this.readAmended && this.dirty != null) {
           if((entry = this.dirty.get(key)) != null && !entry.replace(oldValue, newValue)) {
             entry = null;
           }

--- a/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
+++ b/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
@@ -233,10 +233,9 @@ import java.util.function.IntFunction;
     requireNonNull(oldValue, "oldValue");
     requireNonNull(newValue, "newValue");
     ExpungingValue<V> entry = this.read.get(key);
-    if(entry != null && entry.replace(oldValue, newValue)) return true;
-    if(this.readAmended) {
+    if(entry == null && this.readAmended) {
       synchronized(this.lock) {
-        if(this.readAmended && this.dirty != null) {
+        if(this.readAmended && (entry = this.read.get(key)) == null && this.dirty != null) {
           if((entry = this.dirty.get(key)) != null && !entry.replace(oldValue, newValue)) {
             entry = null;
           }
@@ -248,7 +247,7 @@ import java.util.function.IntFunction;
         }
       }
     }
-    return false;
+    return entry != null && entry.replace(oldValue, newValue);
   }
 
   @Override

--- a/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
+++ b/flare/src/main/java/space/vectrix/flare/SyncMapImpl.java
@@ -237,8 +237,7 @@ import java.util.function.IntFunction;
     if(this.readAmended) {
       synchronized(this.lock) {
         if(this.readAmended && this.dirty != null) {
-          entry = this.dirty.get(key);
-          if(!entry.replace(oldValue, newValue)) {
+          if((entry = this.dirty.get(key)) != null && !entry.replace(oldValue, newValue)) {
             entry = null;
           }
           // The slow path should be avoided, even if the value does


### PR DESCRIPTION
Adds more places where accessing the dirty map for an existing value will mark a miss to try to promote the map. This is so the miss isn't only marked when `get`ing from the map, but also when `put`ing and `replace`ing existing values, so they may take the path that does not require a lock in the future when it is promoted from calling the same method.